### PR TITLE
fix missing days with 0 contribution

### DIFF
--- a/NetworkKit/Sources/NetworkKit/GitHub.swift
+++ b/NetworkKit/Sources/NetworkKit/GitHub.swift
@@ -52,8 +52,8 @@ public struct GitHub {
         let dataCount = try element.attr("data-count")
         let dataDate = try element.attr("data-date")
 
-        guard let colorIndex = colors.firstIndex(where: { $0.contains(fill) }),
-              let count = Int(dataCount),
+        let colorIndex = colors.firstIndex(where: { $0.contains(fill) }) ?? 0
+        guard let count = Int(dataCount),
               let date = dateFormatter.date(from: dataDate)
         else { return nil }
 


### PR DESCRIPTION
Since color for legend and graph differs in github page, the days for 0 contribution are missing in widget.

For a few days the github page has given this as a legend for 0 contributions:
`var (- color-calendar-graph-day-bg)`
Unlike the graph where there is the color code.

Which gives a widget like this:
![IMG_83655A5B33BC-1](https://user-images.githubusercontent.com/8632778/100543366-fa6a2e80-324f-11eb-8d17-5c7c622a143a.jpeg)

When the github page displays:
<img width="366" alt="Capture d’écran 2020-11-29 à 14 29 50" src="https://user-images.githubusercontent.com/8632778/100543311-a7907700-324f-11eb-80cf-db109f78d83c.png">
