### PR TITLE
fix "please adopt containerbackground api" in widget after ios 17.0;

### DIFF
--- a/GitHubContributionsWidget/GitHubContributionsGraphEntryView.swift
+++ b/GitHubContributionsWidget/GitHubContributionsGraphEntryView.swift
@@ -34,6 +34,21 @@ struct GitHubContributionsGraphEntryView: View {
 
 // MARK: -
 
+
+// fix "please adopt containerbackground api" in widget after ios 17.0; ref-> https://stackoverflow.com/a/76842922/8262079
+extension View {
+    func widgetBackground(_ backgroundView: some View) -> some View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            return containerBackground(for: .widget) {
+                backgroundView
+            }
+        } else {
+            return background(backgroundView)
+        }
+    }
+}
+
+
 struct WidgetStyle: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
     let isPureBlackEnabled: Bool
@@ -46,6 +61,6 @@ struct WidgetStyle: ViewModifier {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .padding()
-            .background(backgroundColor)
+            .widgetBackground(backgroundColor)
     }
 }

--- a/GitHubContributionsWidget/GitHubContributionsGraphEntryView.swift
+++ b/GitHubContributionsWidget/GitHubContributionsGraphEntryView.swift
@@ -34,7 +34,6 @@ struct GitHubContributionsGraphEntryView: View {
 
 // MARK: -
 
-
 // fix "please adopt containerbackground api" in widget after ios 17.0; ref-> https://stackoverflow.com/a/76842922/8262079
 extension View {
     func widgetBackground(_ backgroundView: some View) -> some View {

--- a/GitHubContributionsWidget/GitHubContributionsGraphEntryView.swift
+++ b/GitHubContributionsWidget/GitHubContributionsGraphEntryView.swift
@@ -46,8 +46,6 @@ extension View {
         }
     }
 }
-
-
 struct WidgetStyle: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
     let isPureBlackEnabled: Bool


### PR DESCRIPTION
widget shows an error on initialisation after upgrading to iOS 17. This fix is based on https://stackoverflow.com/a/76842922/8262079. Tested on iOS 17.3.1 on iPhone.